### PR TITLE
More PyPy3 test fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "pypy3"]
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-2019]
         exclude:
-          - { python-version: 3.9, os: ubuntu-16.04 }
-          - { python-version: 3.9, os: macos-latest }
-          - { python-version: 3.9, os: windows-2019 }
+          - { python-version: "3.9", os: ubuntu-16.04 }
+          - { python-version: "3.9", os: macos-latest }
+          - { python-version: "3.9", os: windows-2019 }
+          - { python-version: "pypy3", os: macos-latest }
+          - { python-version: "pypy3", os: windows-2019 }
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ python:
 
 jobs:
   fast_finish: true
-  include:
-    - arch: amd64
-      python: pypy3
 
 install:
   - pip install -U pip

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1,5 +1,3 @@
-﻿# coding=UTF-8
-
 import decimal
 import io
 import json


### PR DESCRIPTION
This updates PR https://github.com/ultrajson/ultrajson/pull/413 so the CI passes.

Changes proposed in this pull request:

* Remove BOM from test_ujson.py to fix PyPy3 on Travis CI
  * Remove redundant encoding definition via pyupgrade
* Add PyPy3 to GitHub Actions
* Travis CI is slow, only test PyPy3 on GHA

Example CI builds:

* https://github.com/hugovk/ultrajson/actions/runs/134225312
* https://travis-ci.org/github/hugovk/ultrajson/builds/697942052
